### PR TITLE
Keep recognizing past first utterance

### DIFF
--- a/speech/Objective-C/Speech-gRPC-Streaming/README.md
+++ b/speech/Objective-C/Speech-gRPC-Streaming/README.md
@@ -2,6 +2,25 @@
 
 This app demonstrates how to make streaming gRPC connections to the [Cloud Speech API](https://cloud.google.com/speech/) to recognize speech in recorded audio.
 
+## Continuous streaming
+
+This fork demonstrates how to get real-time recognition results over an entire audio session as opposed to a single utterance. 
+
+Streaming recognition fails silently after ~60 seconds of continuous audio, consistent with the [advertised limit](https://cloud.google.com/speech/limits). Once we start streaming, this time limit applies whether we are silent or speaking. To use streaming recognition over a longer audio session, we take advantage of natural pauses in speech to split the recognition task into discrete transactions. The UITextView retains the `isFinal` transcription response for the previous transaction, scroll it to see all of the returned alternatives. 
+
+This demo relies on the Cloud Speech API to detect pauses in speech and automatically restarts the recognition process with each pause. This has a side effect of resetting the 60 second recognition budget. Locally detecting lack of speech would probably be a more effective approach, and could also be used to reduce the likelihood of missing words while in the (narrow) window between transactions. 
+
+Continuous 16k LINEAR16 requires a stable uplink at 256kbps. If network conditions degrade, you may receive the following response with `response.hasError` set: 
+```
+{
+    error {
+      code: 11
+      message: "Audio data is being streamed too slow. Please stream audio data approximately at real time."
+    }
+}
+```
+It appears that recognition does not proceed after this error, so we start a new transaction to recover from this and other error conditions. 
+
 ## Prerequisites
 - An API key for the Cloud Speech API (See
   [the docs][getting-started] to learn more)

--- a/speech/Objective-C/Speech-gRPC-Streaming/Speech/ViewController.m
+++ b/speech/Objective-C/Speech-gRPC-Streaming/Speech/ViewController.m
@@ -28,7 +28,12 @@
 @property (nonatomic, strong) NSMutableData *audioData;
 @end
 
-@implementation ViewController
+@implementation ViewController {
+  BOOL stopRequested;
+  __block BOOL speechWhileEnding;
+  __block BOOL endingTransaction;
+  BOOL endingStream;
+}
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -37,6 +42,13 @@
 }
 
 - (IBAction)recordAudio:(id)sender {
+  if (sender) {
+    stopRequested = NO;
+    speechWhileEnding = NO;
+    //_startButton.enabled = NO;
+  } else if (stopRequested) {
+    return;
+  }
   AVAudioSession *audioSession = [AVAudioSession sharedInstance];
   [audioSession setCategory:AVAudioSessionCategoryRecord error:nil];
 
@@ -49,11 +61,29 @@
 - (IBAction)stopAudio:(id)sender {
   [[AudioController sharedInstance] stop];
   [[SpeechRecognitionService sharedInstance] stopStreaming];
+  if (sender) {
+    stopRequested = YES;
+    //_startButton.enabled = YES;
+  }
+}
+
+// restart after API error
+- (void) restart {
+  if (endingStream || stopRequested) {
+    return;
+  }
+  endingStream = YES;
+  [self stopAudio:nil];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    endingStream = NO;
+    [self recordAudio:nil];
+  });
 }
 
 - (void) processSampleData:(NSData *)data
 {
   [self.audioData appendData:data];
+#if NO
   NSInteger frameCount = [data length] / 2;
   int16_t *samples = (int16_t *) [data bytes];
   int64_t sum = 0;
@@ -61,10 +91,31 @@
     sum += abs(samples[i]);
   }
   NSLog(@"audio %d %d", (int) frameCount, (int) (sum * 1.0 / frameCount));
-
+#endif
   // We recommend sending samples in 100ms chunks
   int chunk_size = 0.1 /* seconds/chunk */ * SAMPLE_RATE * 2 /* bytes/sample */ ; /* bytes/chunk */
 
+  /*
+   * Streaming recognition fails silently after ~60 of continuous audio. This limit applies whether we are silent or speaking.
+   * To use streaming recognition over a longer session, we take advantage of natural pauses in speech to split the
+   * recognition task into discrete transactions. We rely on the API to detect these pauses and then automatically restart 
+   * the recognition process to reset our 60 second budget.
+   *
+   * Each streaming recognition transaction proceeds roughly as follows:
+   *
+   * start sending audio samples
+   *    no response during initial silence
+   * start speaking (this sequence will repeat if speaker pauses briefly)
+   *    endpointerType: START_OF_SPEECH
+   *    live results (isFinal NO)
+   *    endpointerType: END_OF_SPEECH
+   * stop speaking (aka longer pause or stop speaking)
+   *    final results (isFinal YES)
+   * stop sending audio samples
+   *    endpointerType: END_OF_AUDIO (sometimes repeated, sometimes arrives before isFinal response)
+   * automatically start next transaction
+   *
+   */
   if ([self.audioData length] > chunk_size) {
     NSLog(@"SENDING");
     [[SpeechRecognitionService sharedInstance] streamAudioData:self.audioData
@@ -72,18 +123,48 @@
                                                   if (error) {
                                                     NSLog(@"ERROR: %@", error);
                                                     _textView.text = [error localizedDescription];
-                                                    [self stopAudio:nil];
+                                                    [self restart];
                                                   } else if (response) {
                                                     BOOL finished = NO;
                                                     NSLog(@"RESPONSE: %@", response);
-                                                    for (StreamingRecognitionResult *result in response.resultsArray) {
-                                                      if (result.isFinal) {
-                                                        finished = YES;
+                                                    if (response.hasError) {
+                                                        if (endingTransaction == NO) {
+                                                            [self restart];
+                                                        }
+                                                    } else if (response.endpointerType == StreamingRecognizeResponse_EndpointerType_StartOfSpeech) {
+                                                      if (endingTransaction)
+                                                        speechWhileEnding = YES;
+                                                      _textView.text = nil;
+                                                    } else if (response.endpointerType == StreamingRecognizeResponse_EndpointerType_EndOfSpeech) {
+                                                      if (endingTransaction)
+                                                        speechWhileEnding = YES;
+                                                    } else if (response.endpointerType == StreamingRecognizeResponse_EndpointerType_EndOfAudio) {
+                                                      if (endingTransaction) {
+                                                        endingTransaction = NO;
+                                                        NSLog(@"restarting audio");
+                                                        [self recordAudio:nil];
+                                                      }
+                                                    } else {
+                                                      for (StreamingRecognitionResult *result in response.resultsArray) {
+                                                        if (result.isFinal) {
+                                                          NSLog(@"isFinal");
+                                                          finished = YES;
+                                                          _textView.text = nil;
+                                                        }
                                                       }
                                                     }
-                                                    _textView.text = [response description];
+                                                    _textView.text = [NSString stringWithFormat:@"%@%@", _textView.text, [response description]];
                                                     if (finished) {
-                                                      [self stopAudio:nil];
+                                                      if (endingTransaction) {
+                                                        NSLog(@"don't stop, endingTransaction");
+                                                      } else if (speechWhileEnding) {
+                                                        NSLog(@"don't stop, speechWhileEnding");
+                                                      } else {
+                                                        endingTransaction = YES;
+                                                        NSLog(@"stopping audio");
+                                                        [self stopAudio:nil];
+                                                      }
+                                                      speechWhileEnding = NO;
                                                     }
                                                   }
                                                 }


### PR DESCRIPTION
As discussed in #12 , the demo app stops recognition after the first pause in speech or ~1 minute of audio, whichever comes first. This PR lets recognition proceed as long as you are speaking, by breaking the API interaction into a series of discrete transactions. 
