### PR TITLE
Add word time offsets

### DIFF
--- a/speech/Objective-C/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto
+++ b/speech/Objective-C/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto
@@ -202,6 +202,12 @@ message RecognitionConfig {
 
   // *Optional* A means to provide context to assist the speech recognition.
   repeated SpeechContext speech_contexts = 6;
+
+// *Optional* If ``true``, the top result includes a list of
+// words and the start and end time offsets (timestamps) for
+// those words. If ``false``, no word-level time offset
+// information is returned. The default is ``false``.
+bool enable_word_time_offsets = 8;
 }
 
 // Provides "hints" to the speech recognizer to favor specific words and phrases
@@ -393,4 +399,29 @@ message SpeechRecognitionAlternative {
   // any of the results.
   // The default of 0.0 is a sentinel value indicating `confidence` was not set.
   float confidence = 2;
+
+  // *Output-only* A list of word-specific information for each
+  // recognized word.
+  repeated WordInfo words = 3;
+}
+
+message WordInfo {
+
+  // *Output-only* Time offset relative to the beginning of the
+  // audio, and corresponding to the start of the spoken word. This
+  // field is only set if ``enable_word_time_offsets=true`` and
+  // only in the top hypothesis. This is an experimental feature
+  // and the accuracy of the time offset can vary.
+  google.protobuf.Timestamp start_time = 1;
+
+  // *Output-only* Time offset relative to the beginning of the
+  // audio, and corresponding to the end of the spoken word. This
+  // field is only set if ``enable_word_time_offsets=true`` and
+  // only in the top hypothesis. This is an experimental feature
+  // and the accuracy of the time offset can vary.
+  google.protobuf.Timestamp end_time = 2;
+
+  // *Output-only* The word corresponding to this set of
+  // information.
+  string word = 3;
 }

--- a/speech/Swift/Speech-gRPC-Streaming/Speech/SpeechRecognitionService.swift
+++ b/speech/Swift/Speech-gRPC-Streaming/Speech/SpeechRecognitionService.swift
@@ -59,6 +59,7 @@ class SpeechRecognitionService {
       recognitionConfig.sampleRateHertz = Int32(sampleRate)
       recognitionConfig.languageCode = "en-US"
       recognitionConfig.maxAlternatives = 30
+      recognitionConfig.enableWordTimeOffsets = true
 
       let streamingRecognitionConfig = StreamingRecognitionConfig()
       streamingRecognitionConfig.config = recognitionConfig

--- a/speech/Swift/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto
+++ b/speech/Swift/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto
@@ -202,6 +202,12 @@ message RecognitionConfig {
 
   // *Optional* A means to provide context to assist the speech recognition.
   repeated SpeechContext speech_contexts = 6;
+
+  // *Optional* If ``true``, the top result includes a list of
+  // words and the start and end time offsets (timestamps) for
+  // those words. If ``false``, no word-level time offset
+  // information is returned. The default is ``false``.
+  bool enable_word_time_offsets = 8;
 }
 
 // Provides "hints" to the speech recognizer to favor specific words and phrases

--- a/speech/Swift/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto
+++ b/speech/Swift/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto
@@ -399,4 +399,29 @@ message SpeechRecognitionAlternative {
   // any of the results.
   // The default of 0.0 is a sentinel value indicating `confidence` was not set.
   float confidence = 2;
+
+  // *Output-only* A list of word-specific information for each
+  // recognized word.
+  repeated WordInfo words = 3;
+}
+
+message WordInfo {
+
+  // *Output-only* Time offset relative to the beginning of the
+  // audio, and corresponding to the start of the spoken word. This
+  // field is only set if ``enable_word_time_offsets=true`` and
+  // only in the top hypothesis. This is an experimental feature
+  // and the accuracy of the time offset can vary.
+  google.protobuf.Timestamp start_time = 1;
+
+  // *Output-only* Time offset relative to the beginning of the
+  // audio, and corresponding to the end of the spoken word. This
+  // field is only set if ``enable_word_time_offsets=true`` and
+  // only in the top hypothesis. This is an experimental feature
+  // and the accuracy of the time offset can vary.
+  google.protobuf.Timestamp end_time = 2;
+
+  // *Output-only* The word corresponding to this set of
+  // information.
+  string word = 3;
 }


### PR DESCRIPTION
This PR:

* adds `RecognitionConfig.enableWordTimeOffsets` in `speech/Swift/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto`
* adds `WordInfo` class in `speech/Swift/Speech-gRPC-Streaming/google/cloud/speech/v1/cloud_speech.proto`

Recognition result looks like this:

```
<StreamingRecognizeResponse 0x6000000a3120>: {
    results {
      alternatives {
        transcript: "English do you speak it"
        confidence: 0.987629
        words {
          start_time {
            seconds: 1
          }
          end_time {
            seconds: 1
            nanos: 800000000
          }
          word: "English"
        }
        words {
          start_time {
            seconds: 1
            nanos: 800000000
          }
          end_time {
            seconds: 2
          }
          word: "do"
        }
        words {
          start_time {
            seconds: 2
          }
          end_time {
            seconds: 2
            nanos: 100000000
          }
          word: "you"
        }
[...]
```