### PR TITLE
Update the gRPC version being used in example

### DIFF
--- a/speech/Objective-C/Speech-gRPC-Streaming/googleapis.podspec
+++ b/speech/Objective-C/Speech-gRPC-Streaming/googleapis.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
 
  # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
-  s.dependency "!ProtoCompiler-gRPCPlugin", "~> 1.0.0-pre1.1"
+  s.dependency "!ProtoCompiler-gRPCPlugin", "~> 1.0"
 
   # Pods directory corresponding to this app's Podfile, relative to the location of this podspec.
   pods_root = 'Pods'


### PR DESCRIPTION
gRPC is restricted to versions 1.0.x in the example `speech/Objective-C/Speech-gRPC-Streaming`. This PR allows newer versions to be used.