### PR TITLE
Fix Swift Speech-gRPC-Streaming

### DIFF
--- a/speech/Swift/Speech-gRPC-Streaming/INSTALL-COCOAPODS
+++ b/speech/Swift/Speech-gRPC-Streaming/INSTALL-COCOAPODS
@@ -3,16 +3,6 @@
 echo "Installing Cocoapod dependencies"
 pod install
 
-echo "Clean BoringSSL module.modulemap"
-> Pods/BoringSSL/include/openssl/module.modulemap
-
-echo "Fix the bad imports in the generated files"
-grep -rl "google/cloud/speech/v1beta1/CloudSpeech.pbobjc.h"  google/** | xargs sed -i '' s@'"google\/cloud\/speech\/v1beta1\/CloudSpeech\.pbobjc\.h"'@'\<googleapis\/CloudSpeech\.pbobjc\.h\>'@g
-grep -rl "google/api/Annotations.pbobjc.h"  google/** | xargs sed -i '' s@'"google\/api\/Annotations\.pbobjc\.h"'@'\<googleapis\/Annotations\.pbobjc\.h\>'@g
-grep -rl "google/longrunning/Operations.pbobjc.h"  google/** | xargs sed -i '' s@'"google\/longrunning\/Operations\.pbobjc\.h"'@'\<googleapis\/Operations\.pbobjc\.h\>'@g
-grep -rl "google/rpc/Status.pbobjc.h"  google/** | xargs sed -i '' s@'"google\/rpc\/Status\.pbobjc\.h"'@'\<googleapis\/Status\.pbobjc\.h\>'@g
-grep -rl "google/cloud/speech/v1/CloudSpeech.pbobjc.h"  google/** | xargs sed -i '' s@'"\google\/cloud\/speech\/v1\/CloudSpeech\.pbobjc\.h\"'@'\<googleapis\/CloudSpeech\.pbobjc\.h\>'@g 
-
 echo "Opening the project workspace in Xcode"
 open Speech.xcworkspace
 

--- a/speech/Swift/Speech-gRPC-Streaming/Speech/Speech-Bridging-Header.h
+++ b/speech/Swift/Speech-gRPC-Streaming/Speech/Speech-Bridging-Header.h
@@ -2,5 +2,5 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <googleapis/CloudSpeech.pbobjc.h>
-#import <googleapis/CloudSpeech.pbrpc.h>
+#import <googleapis/google/cloud/speech/v1/CloudSpeech.pbobjc.h>
+#import <googleapis/google/cloud/speech/v1/CloudSpeech.pbrpc.h>


### PR DESCRIPTION
Cocoapods seems to have stopped flattening directory structure in Headers directory of frameworks (which is the correct behavior I think). As a result, the bridging header needs to be changed to make the project build it.

Also, the hacks in INSTALL-COCOAPODS seem to be no longer apply and causing breakage. Removing them.