### PR TITLE
Remove usage of MDCTextFieldTypographyThemer

### DIFF
--- a/speech-to-speech/SpeechToSpeech/ApplicationScheme.swift
+++ b/speech-to-speech/SpeechToSpeech/ApplicationScheme.swift
@@ -28,8 +28,12 @@ class ApplicationScheme: NSObject {
   override init() {
     self.buttonScheme.colorScheme = self.colorScheme
     self.buttonScheme.typographyScheme = self.typographyScheme
+    self.containerScheme.colorScheme = self.colorScheme as! MDCSemanticColorScheme
+    self.containerScheme.typographyScheme = self.typographyScheme as! MDCTypographyScheme
     super.init()
   }
+  
+  public let containerScheme = MDCContainerScheme()
   
   public let buttonScheme = MDCButtonScheme()
   

--- a/speech-to-speech/SpeechToSpeech/ViewController/SettingsViewController.swift
+++ b/speech-to-speech/SpeechToSpeech/ViewController/SettingsViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponents
 import MaterialComponents.MaterialTypographyScheme
 
 class SettingsViewController: UIViewController {
-  var colorScheme = ApplicationScheme.shared.colorScheme
+  var containerScheme = ApplicationScheme.shared.containerScheme
   var typographyScheme = MDCTypographyScheme()
   var selectedTransFrom = ""
   var selectedTransTo   = ""
@@ -127,11 +127,7 @@ class SettingsViewController: UIViewController {
   }
 
   func style(textInputController:MDCTextInputControllerFilled) {
-    MDCFilledTextFieldColorThemer.applySemanticColorScheme(colorScheme, to: textInputController)
-    MDCTextFieldTypographyThemer.applyTypographyScheme(typographyScheme, to: textInputController)
-    if let textInput = textInputController.textInput {
-      MDCTextFieldTypographyThemer.applyTypographyScheme(typographyScheme, to: textInput)
-    }
+    textInputController.applyTheme(withScheme: containerScheme)
     MDCContainedButtonThemer.applyScheme(ApplicationScheme.shared.buttonScheme, to: getStartedButton)
   }
 


### PR DESCRIPTION
This PR removes usage of MDCTextFieldTypographyThemer. More context in linked issue.

Closes https://github.com/GoogleCloudPlatform/ios-docs-samples/issues/138.